### PR TITLE
Fix for Typescript error when injecting reset

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { injectGlobal } from "emotion";
-import { ObjectInterpolation } from "create-emotion";
 
 import reset from "../";
 
-injectGlobal(reset as ObjectInterpolation<any>);
+injectGlobal(reset);
 
 const Example = () => (
   <div>

--- a/reset.css.object.ts
+++ b/reset.css.object.ts
@@ -108,7 +108,7 @@ const reset = {
   sup: generics,
   table: {
     ...generics,
-    borderCollapse: "collapse",
+    borderCollapse: "collapse" as "collapse",
     borderSpacing: 0
   },
   tbody: generics,


### PR DESCRIPTION
Got this annoying typescript error when trying to inject reset to project using `styled-components` and `emoticon` example seems also been affected:
```
Argument of type '{ a: { margin: number; padding: number; border: number; fontSize: string; font: string; verticalAlign: string; }; abbr: { margin: number; padding: number; border: number; fontSize: string; font: string; verticalAlign: string; }; ... 78 more ...; video: { ...; }; }' is not assignable to parameter of type 'Interpolation<ThemeProps<DefaultTheme>>'.
  Type '{ a: { margin: number; padding: number; border: number; fontSize: string; font: string; verticalAlign: string; }; abbr: { margin: number; padding: number; border: number; fontSize: string; font: string; verticalAlign: string; }; ... 78 more ...; video: { ...; }; }' is not assignable to type 'CSSObject'.
    Type '{ a: { margin: number; padding: number; border: number; fontSize: string; font: string; verticalAlign: string; }; abbr: { margin: number; padding: number; border: number; fontSize: string; font: string; verticalAlign: string; }; ... 78 more ...; video: { ...; }; }' is not assignable to type '{ [x: string]: string | number | CSSObject | undefined; }'.
      Property 'table' is incompatible with index signature.
        Type '{ borderCollapse: string; borderSpacing: number; margin: number; padding: number; border: number; fontSize: string; font: string; verticalAlign: string; }' is not assignable to type 'string | number | CSSObject | undefined'.
          Type '{ borderCollapse: string; borderSpacing: number; margin: number; padding: number; border: number; fontSize: string; font: string; verticalAlign: string; }' is not assignable to type 'CSSObject'.
            Type '{ borderCollapse: string; borderSpacing: number; margin: number; padding: number; border: number; fontSize: string; font: string; verticalAlign: string; }' is not assignable to type 'Properties<ReactText>'.
              Types of property 'borderCollapse' are incompatible.
                Type 'string' is not assignable to type '"-moz-initial" | "inherit" | "initial" | "revert" | "unset" | "collapse" | "separate" | undefined'.
```

Solved this by casting that borderCollapse value to string literal `collapse` and tested that example no longer gives error for `emoticon`. Also tested with my own project that uses `styled-components`.

By the way handy library Iiro 💪🍺 